### PR TITLE
docs: Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ All queries can search on multuple fields (except for `facet_query` because it d
 So, the following query:
 
 ```ruby
-index.term_query(%i[title, description], "hello")
+index.term_query(%i[title description], "hello")
 ```
 
 Is equivalent to:


### PR DESCRIPTION
Thank you for publishing very interesting library!

I ran sample code in the README and got an error `Tantiny::UnsupportedField: Can't search the "title," field with this query.
`.
This patch seemed to fix it.