### PR TITLE
fix: Fix native extensions build on Ruby <= 3.1

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,5 +1,5 @@
 require "thermite/tasks"
 
-project_dir = File.dirname(__FILE__, 2)
+project_dir = File.dirname(File.dirname(__FILE__)) # rubocop:disable Style/NestedFileDirname
 Thermite::Tasks.new(cargo_project_path: project_dir, ruby_project_path: project_dir)
 task default: %w[thermite:build]


### PR DESCRIPTION
See: https://docs.rubocop.org/rubocop/cops_style.html#stylenestedfiledirname

Fixes #9 